### PR TITLE
fix: 🐛 Fix scraper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17 as builder
+FROM node:14.17 AS builder
 
 RUN useradd -ms /bin/bash appuser
 COPY ./planer-uwr-webapp /home/appuser/planer-uwr-webapp

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ USER appuser
 WORKDIR /home/appuser
 
 RUN mkdir ~/.npm-global && npm config set prefix '~/.npm-global' && export PATH=~/.npm-global/bin:$PATH
-RUN npm install -g meteor
+RUN npm install -g meteor@2.16.0 
 WORKDIR /home/appuser/planer-uwr-webapp
 RUN npm install --production
 RUN /home/appuser/.meteor/meteor build /home/appuser/build

--- a/planer-uwr-scraping/spiders/courses.py
+++ b/planer-uwr-scraping/spiders/courses.py
@@ -38,7 +38,7 @@ class CoursesSpider(scrapy.Spider):
 
     def parse(self, response):
         semesters = [{'url': sem.css('::attr(href)').get(), 'name': sem.css('::text').get()} for sem in
-                     response.css('#sidebar-inner > div > div > div > a')]
+                     response.css('.dropdown-menu[aria-labelledby="semester-dropdown"] a.dropdown-item.semester-link')]
         for sem in semesters:
             yield scrapy.Request(url=response.urljoin(sem['url']), callback=self.parse_semester(sem['name']),
                                  dont_filter=True)

--- a/planer-uwr-webapp/imports/ui/pages/PlanPage/Listing/ListingWrapper.tsx
+++ b/planer-uwr-webapp/imports/ui/pages/PlanPage/Listing/ListingWrapper.tsx
@@ -10,27 +10,13 @@ import { Course, Courses } from '/imports/api/courses';
 
 const semestersNames = [
   'Oferta',
-  '2022/23 zimowy',
-  '2021/22 letni',
-  '2021/22 zimowy',
-  '2020/21 letni',
-  '2020/21 zimowy',
-  '2019/20 letni',
-  '2019/20 zimowy',
-  '2018/19 letni',
-  '2018/19 zimowy',
-  '2017/18 letni',
-  '2017/18 zimowy',
-  '2016/17 letni',
-  '2016/17 zimowy',
-  '2015/16 letni',
-  '2015/16 zimowy',
-  '2014/15 letni',
-  '2014/15 zimowy',
-  '2013/14 letni',
-  '2013/14 zimowy',
-  '2012/13 letni',
-  '2012/13 zimowy',
+  '2025/26 zimowy',
+  '2024/25 letni',
+  '2024/25 zimowy',
+  '2023/24 letni',
+  '2023/24 zimowy',
+  '2022/23 letni',
+  '2022/23 zimowy'
 ];
 
 interface ListingWrapperProps {


### PR DESCRIPTION
This PR fixes the CSS selector for the courses scraper and adds the semester names in the UI.

Additionally, it also sets the meteor version to the highest that will work with node 14.17.